### PR TITLE
Generalize jupyter flag for regularInteractive

### DIFF
--- a/bin/regularInteractive
+++ b/bin/regularInteractive
@@ -3,7 +3,7 @@
 host=`hostname`
 
 name=neuroglia_interactive
-jupyter_script=/project/6007967/tkai/venv/jupyter.sh
+jupyter_script=$NEUROGLIA_DIR/etc/jupyter.sh
 cpus=8
 hours=3
 mem=32000

--- a/etc/jupyter.sh
+++ b/etc/jupyter.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+unset XDG_RUNTIME_DIR
+jupyter lab --ip $(hostname -f) --no-browser


### PR DESCRIPTION
- Moved jupyter.sh script from user directory into neuroglia-helpers for generalizability
  - Retained symlink locally so it doesn't break for any current users yet (to be deprecrated in the future)
- Changed pathing in regularInteractive script from user folder to $NEUROGLIA_DIR/etc/jupyter.sh
  - Will require $NEURGOLIA_DIR to be set; should be done during initial config