### PR TITLE
Update singularity/3.2 to singularity/3.4

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -10,6 +10,6 @@ else
   cfg_profile=
 fi
 
-echo "module load singularity/3.2" >> ~/.bash_profile
+echo "module load singularity/3.4" >> ~/.bash_profile
 echo "cfg_profile=${cfg_profile}" >> ~/.bash_profile
 echo "source $execpath/00_init.sh" >> ~/.bash_profile


### PR DESCRIPTION
```singularity/3.2 no longer works on Graham login and compute nodes```

An update to make use of `singularity/3.4`. With `singularity/3.2`, singularity commands are not found.

It was noted that singularity/3.4 was previously not available on `gra-vdi`, hence the use of singularity/3.2. Unsure if singularity/3.4 now works on gra-vdi - if not need an additional fix to identify which node user is on.