### PR TITLE
graham_lpalaniy.cfg

### DIFF
--- a/cfg/graham_lpalaniy.cfg
+++ b/cfg/graham_lpalaniy.cfg
@@ -11,7 +11,6 @@ NEUROGLIA_URI="docker://khanlab/neuroglia-core:latest"
 SINGULARITY_DIR=/project/6033503/singularity  # comment this line and uncomment line below to use personal singularity folder
 SINGULARITY_TMPDIR=/tmp #tmp folder for building images
 
-
 #see if SLURM_TMPDIR would work instead?
 JOB_SCRATCH_DIR=/scratch/${USER}/${SLURM_JOB_ID}_${SLURM_ARRAY_TASK_ID}
 ALT_JOB_SCRATCH_DIR=$SLURM_TMPDIR
@@ -24,15 +23,3 @@ SINGULARITYENV_TEMPLATEFLOW_HOME=/home/fmriprep/.cache/templateflow #for newer f
 FS_LICENSE_FILE=/project/6033503/shared/.license
 GRAD_COEFF_7T=/project/6033503/shared/.coeff_AC84.grad
 #BEAST_PATH=/project/6007967/xiaobird/beast
-
-#set path to local install of fsleyes - for generating snapshots, or visualization on gra-vdi
-PATH=$PATH:/project/6007967/software/fsleyes_0.27.3
-if [ "${HOSTNAME:4:3}" = "vdi" ]
-then
-  #fsl
-  module load StdEnv
-  module load fsl
-
-  #itksnap
-  export PATH=${PATH}:/project/6007967/software/itksnap-3.8.0-20190612-Linux-gcc64-qt4/bin
-fi

--- a/cfg/graham_lpalaniy.cfg
+++ b/cfg/graham_lpalaniy.cfg
@@ -1,0 +1,38 @@
+# compute canada rrg:
+CC_COMPUTE_ALLOC=rrg-lpalaniy #for compute resources
+CC_STORAGE_ALLOC=rrg-lpalaniy #for compute resources
+CC_GPU_ALLOC=rrg-lpalaniy_gpu #for compute resources
+
+#Singularity options
+SINGULARITY_OPTS="-e -B /cvmfs:/cvmfs -B /project:/project -B /scratch:/scratch -B /localscratch:/localscratch"
+NEUROGLIA_URI="docker://khanlab/neuroglia-core:latest"
+
+# paths for storing singularity images - default: shared singularity folder in akhanf
+SINGULARITY_DIR=/project/6033503/singularity  # comment this line and uncomment line below to use personal singularity folder
+SINGULARITY_TMPDIR=/tmp #tmp folder for building images
+
+
+#see if SLURM_TMPDIR would work instead?
+JOB_SCRATCH_DIR=/scratch/${USER}/${SLURM_JOB_ID}_${SLURM_ARRAY_TASK_ID}
+ALT_JOB_SCRATCH_DIR=$SLURM_TMPDIR
+
+# app-specific settings we can distribute
+FMRIPREP_MULTIPROC_YAML=$NEUROGLIA_DIR/cfg_apps/fmriprep_multiproc_8c_32gb.yaml
+SINGULARITYENV_TEMPLATEFLOW_HOME=/home/fmriprep/.cache/templateflow #for newer fmriprep versions that require templateflow
+
+#files we can't distribute:
+FS_LICENSE_FILE=/project/6033503/shared/.license
+GRAD_COEFF_7T=/project/6033503/shared/.coeff_AC84.grad
+#BEAST_PATH=/project/6007967/xiaobird/beast
+
+#set path to local install of fsleyes - for generating snapshots, or visualization on gra-vdi
+PATH=$PATH:/project/6007967/software/fsleyes_0.27.3
+if [ "${HOSTNAME:4:3}" = "vdi" ]
+then
+  #fsl
+  module load StdEnv
+  module load fsl
+
+  #itksnap
+  export PATH=${PATH}:/project/6007967/software/itksnap-3.8.0-20190612-Linux-gcc64-qt4/bin
+fi


### PR DESCRIPTION
Added new graham config for `rrg-lpalaniy` with directories changed to point to group directories. Mainly to setup singularity images (to be synced with `rrg-akhanf` singularity images) for group.

BEAST is left commented (unsure if it is required for anything, also in terms of access not sure if users under `rrg-lpalaniy` would have access). 

Two variables need to be changed/added later on:
1. `FS_LICENSE_FILE` - Freesurfer license
2. `GRAD_COEFF_7T`- For gradient correction of images off 7T scanner