### PR TITLE
Bids apps tsv fix

### DIFF
--- a/bids-apps.tsv
+++ b/bids-apps.tsv
@@ -51,7 +51,7 @@ mp2rage_correction_v0.0.5	docker://khanlab/mp2rage_correction:v0.0.5		ShortSkinn
 mp2rage_correction_v0.0.4a	docker://khanlab/mp2rage_correction:v0.0.4a		ShortSkinny
 mp2rage_correction_dev	docker://khanlab/mp2rage_correction:latest		ShortSkinny
 mp2rage_correction_v0.0.3	shub://khanlab/mp2rage_correction:v0.0.3		ShortSkinny
-gradcorrect_v0.0.3a docker://khanlab/gradcorrect:v0.0.3a  --grad_coeff_file ${GRAD_COEFF_7T}  4core16gb12h
+gradcorrect_v0.0.3a	docker://khanlab/gradcorrect:v0.0.3a	--grad_coeff_file ${GRAD_COEFF_7T}	4core16gb12h
 gradcorrect_v0.0.3	docker://khanlab/gradcorrect:v0.0.3	--grad_coeff_file ${GRAD_COEFF_7T}	4core16gb12h
 gradcorrect_v0.0.2	docker://khanlab/gradcorrect:v0.0.2	--grad_coeff_file ${GRAD_COEFF_7T}	4core16gb12h
 freesurfer_v6.0.1-subfields	file:///project/6007967/akhanf/singularity/bids-apps/khanlab_freesurfer_v6.0.1-subfields.img	--license_file ${FS_LICENSE_FILE} --n_cpus 8  --skip_bids_validator --hires_mode enable	Regular

--- a/bids-apps.tsv
+++ b/bids-apps.tsv
@@ -50,7 +50,7 @@ qsm_sstv_v0.1.1	shub://AlanKuurstra/qsm_sstv:v0.1.1	--SS_TV_lagrange_parameter 0
 mp2rage_correction_v0.0.5	docker://khanlab/mp2rage_correction:v0.0.5		ShortSkinny
 mp2rage_correction_v0.0.4a	docker://khanlab/mp2rage_correction:v0.0.4a		ShortSkinny
 mp2rage_correction_dev	docker://khanlab/mp2rage_correction:latest		ShortSkinny
-mp2rage_correction_v0.0.3 shub://khanlab/mp2rage_correction:v0.0.3    ShortSkinny
+mp2rage_correction_v0.0.3	shub://khanlab/mp2rage_correction:v0.0.3		ShortSkinny
 gradcorrect_v0.0.3a docker://khanlab/gradcorrect:v0.0.3a  --grad_coeff_file ${GRAD_COEFF_7T}  4core16gb12h
 gradcorrect_v0.0.3	docker://khanlab/gradcorrect:v0.0.3	--grad_coeff_file ${GRAD_COEFF_7T}	4core16gb12h
 gradcorrect_v0.0.2	docker://khanlab/gradcorrect:v0.0.2	--grad_coeff_file ${GRAD_COEFF_7T}	4core16gb12h
@@ -62,4 +62,4 @@ mdt-bids_v0.1	docker://khanlab/mdt-bids:v0.1		ShortFat
 surfmorph_v0.1	docker://khanlab/surfmorph:v0.1		ShortSkinny
 surfmorph_dev	docker://khanlab/surfmorph:latest		ShortSkinny
 qsiprep_0.8.0RC3	docker://pennbbl/qsiprep:0.8.0RC3	-w $SLURM_TMPDIR --fs-license-file ${FS_LICENSE_FILE}	Regular
-fmriprep_ciftify_v1.3.2-2.3.3   docker pull tigrlab/fmriprep_ciftify:v1.3.2-2.3.3       Regular
+fmriprep_ciftify_v1.3.2-2.3.3	docker pull tigrlab/fmriprep_ciftify:v1.3.2-2.3.3		Regular

--- a/bids-apps.tsv
+++ b/bids-apps.tsv
@@ -50,8 +50,8 @@ qsm_sstv_v0.1.1	shub://AlanKuurstra/qsm_sstv:v0.1.1	--SS_TV_lagrange_parameter 0
 mp2rage_correction_v0.0.5	docker://khanlab/mp2rage_correction:v0.0.5		ShortSkinny
 mp2rage_correction_v0.0.4a	docker://khanlab/mp2rage_correction:v0.0.4a		ShortSkinny
 mp2rage_correction_dev	docker://khanlab/mp2rage_correction:latest		ShortSkinny
-mp2rage_correction_v0.0.3	shub://khanlab/mp2rage_correction:v0.0.3		ShortSkinny
-gradcorrect_v0.0.3a docker://khanlab/gradcorrect:v0.0.3a	--grad_coeff_file ${GRAD_COEFF_7T}	4core16gb12h
+mp2rage_correction_v0.0.3 shub://khanlab/mp2rage_correction:v0.0.3    ShortSkinny
+gradcorrect_v0.0.3a docker://khanlab/gradcorrect:v0.0.3a  --grad_coeff_file ${GRAD_COEFF_7T}  4core16gb12h
 gradcorrect_v0.0.3	docker://khanlab/gradcorrect:v0.0.3	--grad_coeff_file ${GRAD_COEFF_7T}	4core16gb12h
 gradcorrect_v0.0.2	docker://khanlab/gradcorrect:v0.0.2	--grad_coeff_file ${GRAD_COEFF_7T}	4core16gb12h
 freesurfer_v6.0.1-subfields	file:///project/6007967/akhanf/singularity/bids-apps/khanlab_freesurfer_v6.0.1-subfields.img	--license_file ${FS_LICENSE_FILE} --n_cpus 8  --skip_bids_validator --hires_mode enable	Regular


### PR DESCRIPTION
fixed tsv file formatting bug introduced April 16 2020 -- any bidsBatch runs using neuroglia-helpers pulled since April 16 2020 should be verified to make sure the correct singularity container or options was run