### PR TITLE
[BUG] Fix inability to set `min_avgmb` 

### DIFF
--- a/bin/archivefolders
+++ b/bin/archivefolders
@@ -36,7 +36,7 @@ then
 fi
 
 
-while getopts "N:a:t:no:m" options; do
+while getopts "N:a:t:o:m:n" options; do
  case $options in
     N ) echo "min_nfiles=$OPTARG"; min_nfiles=$OPTARG;;
     a ) echo "account=$OPTARG"; account=$OPTARG;;


### PR DESCRIPTION
## Problem 

Unable to set `-m` flag when using `archivefolders`. When setting value, would always return `setting min_avgmb=`
Error was produced by running the following: `archivefolders -N 5 -a rrg-lpalaniy -m 30 fmriprep` from master branch of repo.

## Fix

Reordered `getopts` (line 39) such that flag can now be set, while still ensuring dry-run functionality. Solution found by reoordering until it flag could be set so there may be better way of ensuring `-m` flag works.