### PR TITLE
fix for apptainer in shub-cache scripts

### DIFF
--- a/bin/shub-cache
+++ b/bin/shub-cache
@@ -40,8 +40,14 @@ bra=master
 
 #check version of singularity (2 vs 3)
 version=`singularity --version`
-version=${version##*\ }
-version=${version:0:1}
+
+if [ ${version%%\ *} = "apptainer" ]
+then
+  version=3
+else
+  version=${version##*\ }
+  version=${version:0:1}
+fi
 
 hub=${url%%://*}
 if [ "$hub" = "docker" ]

--- a/bin/shub-cache-remote
+++ b/bin/shub-cache-remote
@@ -26,14 +26,27 @@ ident=$3
 
 #first make sure that singularity version is same on both (e.g. cannot have v2 v3 mismatch - since shub-cache names files differently for each)
 version=`singularity --version`
-version=${version##*\ }
-version=${version:0:1}
+
+if [ ${version%%\ *} = "apptainer" ]
+then
+  version=3
+else
+  version=${version##*\ }
+  version=${version:0:1}
+fi
+
 local_v=$version
 
 
 version=`ssh -i $ident $user_host singularity --version`
-version=${version##*\ }
-version=${version:0:1}
+
+if [ ${version%%\ *} = "apptainer" ]
+then
+  version=3
+else
+  version=${version##*\ }
+  version=${version:0:1}
+fi
 remote_v=$version
 
 if [ !  "$local_v" = "$remote_v" ]

--- a/bin/shub-upgrade
+++ b/bin/shub-upgrade
@@ -5,11 +5,11 @@
 #[ "${FLOCKER}" != "$0" ] && exec env FLOCKER="$0" flock -en "$0" "$0" "$@" || :
 
 
-if [ ! -n "$SINGULARITY_DIR" ]
-then
-	echo "SINGULARITY_DIR not set, reverting to default: /project/6007967/akhanf/singularity" >&2
-	export SINGULARITY_DIR=/project/6007967/akhanf/singularity
-fi
+#if [ ! -n "$SINGULARITY_DIR" ]
+#then
+#	echo "SINGULARITY_DIR not set, reverting to default: /project/6007967/akhanf/singularity" >&2
+#	export SINGULARITY_DIR=/project/6007967/akhanf/singularity
+#fi
 
 if [ ! "$#" = 1 ]
 then
@@ -31,8 +31,15 @@ bra=master
 
 #check version of singularity (2 vs 3)
 version=`singularity --version`
-version=${version##*\ }
-version=${version:0:1}
+
+if [ ${version%%\ *} = "apptainer" ]
+then
+  version=3
+else
+  version=${version##*\ }
+  version=${version:0:1}
+fi
+
 
 
 hub=${url%%://*}


### PR DESCRIPTION
Was checking version of singularity to see whether it pulls as .sif or .simg files.
Now with apptainer, we just force the same behaviour as if it were singularity 3.x

